### PR TITLE
1. 将按键按下计数，由静态8位变量，改为16位变量计数

### DIFF
--- a/ABFM03/Core/ZJ_Drivers/ZJ_Src/02_Key_Process.c
+++ b/ABFM03/Core/ZJ_Drivers/ZJ_Src/02_Key_Process.c
@@ -539,9 +539,9 @@ void Dealwith_testmode_level_dec_long(void) //
 **************************************************************************************/
 static void get_key_msg(struct_KeyInfo* pInfo)
 {
-  static uint8_t power_key_press_cnt;
-  static uint8_t level_add_key_press_cnt;
-  static uint8_t level_dec_key_press_cnt;
+  static uint16_t power_key_press_cnt;
+  static uint16_t level_add_key_press_cnt;
+  static uint16_t level_dec_key_press_cnt;
 
   switch(pInfo->CurKey)
   {


### PR DESCRIPTION
   a.因为按键按下为10ms查询函数，
     定义长按为2s，即200个计数，当一直长按按键，会出现短按按键混入到长按按键中